### PR TITLE
Add database name to connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ dokku rethinkdb:link lolipop playground
 #
 # and the following will be set on the linked application by default
 #
-#   RETHINKDB_URL=rethinkdb://dokku-rethinkdb-lolipop:28015
+#   RETHINKDB_URL=rethinkdb://dokku-rethinkdb-lolipop:28015/lolipop
 #
 # NOTE: the host exposed here only works internally in docker containers. If
 # you want your container to be reachable from outside, you should use `expose`.
@@ -115,7 +115,7 @@ dokku rethinkdb:link other_service playground
 # since RETHINKDB_URL is already in use, another environment variable will be
 # generated automatically
 #
-#   DOKKU_RETHINKDB_BLUE_URL=rethinkdb://dokku-rethinkdb-other-service:28015
+#   DOKKU_RETHINKDB_BLUE_URL=rethinkdb://dokku-rethinkdb-other-service:28015/other_service
 
 # you can then promote the new service to be the primary one
 # NOTE: this will restart your app
@@ -125,9 +125,9 @@ dokku rethinkdb:promote other_service playground
 # another environment variable to hold the previous value if necessary.
 # you could end up with the following for example:
 #
-#   RETHINKDB_URL=rethinkdb://dokku-rethinkdb-other-service:28015
-#   DOKKU_RETHINKDB_BLUE_URL=rethinkdb://dokku-rethinkdb-other-service:28015
-#   DOKKU_RETHINKDB_SILVER_URL=rethinkdb://dokku-rethinkdb-lolipop:28015
+#   RETHINKDB_URL=rethinkdb://dokku-rethinkdb-other-service:28015/other_service
+#   DOKKU_RETHINKDB_BLUE_URL=rethinkdb://dokku-rethinkdb-other-service:28015/other_service
+#   DOKKU_RETHINKDB_SILVER_URL=rethinkdb://dokku-rethinkdb-lolipop:28015/other_service
 
 # you can also unlink an rethinkdb service
 # NOTE: this will restart your app and unset related environment variables
@@ -152,7 +152,7 @@ dokku rethinkdb:link lolipop playground
 ```
 
 Will cause RETHINKDB_URL to be set as
-rethinkdb2://lolipop:SOME_PASSWORD@dokku-rethinkdb-lolipop:28015
+rethinkdb2://lolipop:SOME_PASSWORD@dokku-rethinkdb-lolipop:28015/lolipop
 
 CAUTION: Changing RETHINKDB_DATABASE_SCHEME after linking will cause dokku to
 believe the rethinkdb is not linked when attempting to use `dokku rethinkdb:unlink`

--- a/functions
+++ b/functions
@@ -89,5 +89,5 @@ service_start() {
 service_url() {
   local SERVICE="$1"
   local SERVICE_ALIAS="$(service_alias "$SERVICE")"
-  echo "$PLUGIN_SCHEME://$SERVICE_ALIAS:${PLUGIN_DATASTORE_PORTS[0]}"
+  echo "$PLUGIN_SCHEME://$SERVICE_ALIAS:${PLUGIN_DATASTORE_PORTS[0]}/$SERVICE"
 }

--- a/tests/service_info.bats
+++ b/tests/service_info.bats
@@ -33,7 +33,7 @@ teardown() {
 
 @test "($PLUGIN_COMMAND_PREFIX:info) success with flag" {
   run dokku "$PLUGIN_COMMAND_PREFIX:info" l --dsn
-  assert_output "rethinkdb://dokku-rethinkdb-l:28015"
+  assert_output "rethinkdb://dokku-rethinkdb-l:28015/l"
 
   run dokku "$PLUGIN_COMMAND_PREFIX:info" l --config-dir
   assert_success

--- a/tests/service_promote.bats
+++ b/tests/service_promote.bats
@@ -39,22 +39,22 @@ teardown() {
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:promote) changes RETHINKDB_URL" {
-  dokku config:set my_app "RETHINKDB_URL=rethinkdb://host:28015" "DOKKU_RETHINKDB_BLUE_URL=rethinkdb://dokku-rethinkdb-l:28015"
+  dokku config:set my_app "RETHINKDB_URL=rethinkdb://host:28015" "DOKKU_RETHINKDB_BLUE_URL=rethinkdb://dokku-rethinkdb-l:28015/l"
   dokku "$PLUGIN_COMMAND_PREFIX:promote" l my_app
   url=$(dokku config:get my_app RETHINKDB_URL)
-  assert_equal "$url" "rethinkdb://dokku-rethinkdb-l:28015"
+  assert_equal "$url" "rethinkdb://dokku-rethinkdb-l:28015/l"
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:promote) creates new config url when needed" {
-  dokku config:set my_app "RETHINKDB_URL=rethinkdb://host:28015" "DOKKU_RETHINKDB_BLUE_URL=rethinkdb://dokku-rethinkdb-l:28015"
+  dokku config:set my_app "RETHINKDB_URL=rethinkdb://host:28015" "DOKKU_RETHINKDB_BLUE_URL=rethinkdb://dokku-rethinkdb-l:28015/l"
   dokku "$PLUGIN_COMMAND_PREFIX:promote" l my_app
   run dokku config my_app
   assert_contains "${lines[*]}" "DOKKU_RETHINKDB_"
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:promote) uses RETHINKDB_DATABASE_SCHEME variable" {
-  dokku config:set my_app "RETHINKDB_DATABASE_SCHEME=rethinkdb2" "RETHINKDB_URL=rethinkdb://u:p@host:28015" "DOKKU_RETHINKDB_BLUE_URL=rethinkdb2://dokku-rethinkdb-l:28015"
+  dokku config:set my_app "RETHINKDB_DATABASE_SCHEME=rethinkdb2" "RETHINKDB_URL=rethinkdb://u:p@host:28015" "DOKKU_RETHINKDB_BLUE_URL=rethinkdb2://dokku-rethinkdb-l:28015/l"
   dokku "$PLUGIN_COMMAND_PREFIX:promote" l my_app
   url=$(dokku config:get my_app RETHINKDB_URL)
-  assert_equal "$url" "rethinkdb2://dokku-rethinkdb-l:28015"
+  assert_equal "$url" "rethinkdb2://dokku-rethinkdb-l:28015/l"
 }


### PR DESCRIPTION
Maybe make sense to explicitly set database name in connection string?

Client setup will be easier in our case:
```js
const pool = rpool(r, process.env.RETHINKDB_URL)
// instead of
const pool = rpool(r, { db: 'blablabla', url: process.env.RETHINKDB_URL })
```

It is not a real PR, i just want to show my idea. 
Will update tests if this change is fine for everyone.