### PR TITLE
fix: allow config directory to be configurable

### DIFF
--- a/common-functions
+++ b/common-functions
@@ -383,7 +383,7 @@ service_info() {
   local flag key valid_flags
 
   local flag_map=(
-    "--config-dir: ${SERVICE_ROOT}/config"
+    "--config-dir: ${SERVICE_ROOT}/${PLUGIN_CONFIG_SUFFIX}"
     "--data-dir: ${SERVICE_ROOT}/data"
     "--dsn: ${SERVICE_URL}"
     "--exposed-ports: $(service_exposed_ports "$SERVICE")"

--- a/config
+++ b/config
@@ -21,6 +21,7 @@ export PLUGIN_SCHEME="rethinkdb"
 export PLUGIN_SERVICE="RethinkDB"
 export PLUGIN_VARIABLE="RETHINKDB"
 export PLUGIN_BASE_PATH="$PLUGIN_PATH"
+export PLUGIN_CONFIG_SUFFIX="config"
 if [[ -n $DOKKU_API_VERSION ]]; then
   export PLUGIN_BASE_PATH="$PLUGIN_ENABLED_PATH"
 fi

--- a/functions
+++ b/functions
@@ -40,7 +40,7 @@ service_create() {
 
   mkdir -p "$SERVICE_ROOT" || dokku_log_fail "Unable to create service directory"
   mkdir -p "$SERVICE_ROOT/data" || dokku_log_fail "Unable to create service data directory"
-  mkdir -p "$SERVICE_ROOT/config" || dokku_log_fail "Unable to create service config directory"
+  mkdir -p "$SERVICE_ROOT/$PLUGIN_CONFIG_SUFFIX" || dokku_log_fail "Unable to create service config directory"
   touch "$LINKS_FILE"
 
   [[ -n "$SERVICE_CUSTOM_ENV" ]] && RETHINKDB_CUSTOM_ENV="$SERVICE_CUSTOM_ENV"

--- a/subcommands/destroy
+++ b/subcommands/destroy
@@ -45,7 +45,7 @@ service-destroy-cmd() {
   service_container_rm "$SERVICE"
 
   dokku_log_verbose_quiet "Removing data"
-  docker run --rm -v "$SERVICE_HOST_ROOT/data:/data" -v "$SERVICE_HOST_ROOT/config:/config" "$PLUGIN_BUSYBOX_IMAGE" chmod 777 -R /config /data
+  docker run --rm -v "$SERVICE_HOST_ROOT/data:/data" -v "$SERVICE_HOST_ROOT/$PLUGIN_CONFIG_SUFFIX:/config" "$PLUGIN_BUSYBOX_IMAGE" chmod 777 -R /config /data
   rm -rf "$SERVICE_ROOT"
 
   dokku_log_info2 "$PLUGIN_SERVICE container deleted: $SERVICE"


### PR DESCRIPTION
For postgres, the config directory doesn't actually exist, so adding this configurability allows the plugin's info command to report correctly.